### PR TITLE
move var rule changes to team specific section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -117,9 +117,9 @@ dotnet_naming_style.pascal_case_style.capitalization                            
 ###############################
 [*.cs]
 # var preferences
-csharp_style_var_for_built_in_types = false:silent
-csharp_style_var_when_type_is_apparent = false:suggestion
-csharp_style_var_elsewhere = false:silent
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:silent
 # Expression-bodied members
 csharp_style_expression_bodied_methods = false:none
 csharp_style_expression_bodied_constructors = false:none
@@ -1081,3 +1081,10 @@ dotnet_diagnostic.CA1303.severity = none # Prefer inline strings in sample code 
 
 [*]
 quote_type = single
+
+[*.cs]
+# var preferences
+# demonstration code should use explicit types for improved readability
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_elsewhere = false:silent   


### PR DESCRIPTION
The previous change was for the editor config, and this change moves the rule into a new spot in the file. I can make a new version of the sample and everything, but it feels like an addendum to the previous PR, so for now it's just a standalone file change. 